### PR TITLE
Optimize Spin Performance

### DIFF
--- a/operate.py
+++ b/operate.py
@@ -9,12 +9,11 @@ ctypes.windll.shcore.SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)
 
 
 def spin(t: float):
-    st = time.time()
+    start_time = time.perf_counter()
     while True:
-        if time.time() - st > t:
+        if time.perf_counter() - start_time > t:
             break
-        for _ in range(10000):
-            pass
+        time.sleep(0)
 
 
 class Mouse:


### PR DESCRIPTION
经过实测，优化后能大幅减少循环次数，10ms大约需要22k次循环，而原来的代码需要500k次循环。

使用 `perf_counter()` 可以得到更高精度的计时，实测 `time()` 方法存在误差，在1ms左右上下浮动，不稳定。